### PR TITLE
Create fewer arrays and prevent sync attribute stringification

### DIFF
--- a/src/genz.mjs
+++ b/src/genz.mjs
@@ -12,8 +12,6 @@ export function createTag (name, isVoid, opener) {
     arguments.__IS_ARGUMENTS__ = true;
 
     // 1. If attibutes are passed
-    let a;
-    let attr;
     if (
       a0 &&
       !a0.__IS_ARGUMENTS__ &&
@@ -21,13 +19,7 @@ export function createTag (name, isVoid, opener) {
       typeof a0.then !== 'function' &&
       !Array.isArray(a0)
     ) {
-      for (a in a0) {
-        if (a.startsWith('__')) continue;
-        if (!attr) attr = [];
-        attr.push(` ${a}="${a0[a]}"`);
-      }
-      attr.push('>');
-      arguments[0] = attr;
+      a0.__IS_ATTRIBUTES__ = true;
 
       if (isVoid) {
         arguments[-1] = opener;
@@ -96,7 +88,22 @@ export function traverse (arr, ctx = {}) {
         if (value.then) return value;
 
         // return a child string
-        return typeof value === 'string' ? value : String(value);
+        if (typeof value === 'string') {
+          return value;
+        } else if (value.__IS_ATTRIBUTES__) {
+          let a;
+          let str = '';
+          for (a in value) {
+            if (a === '__IS_ATTRIBUTES__') continue;
+            // not supporting kebab case because i dont thing the ergonomics are worth it
+            // could be talked out of that...
+            str += ` ${a}="${value[a]}"`;
+          }
+          str += '>';
+          return str;
+        } else {
+          return String(value);
+        }
 
       } else if (queue_i[0] >= queue_a[0].length) {
 

--- a/test/sync.mjs
+++ b/test/sync.mjs
@@ -13,6 +13,19 @@ const syncStringify = (it) => {
 }
 
 export default [
+
+  function TEST_BASIC () {
+    const tag = _.div('hello', _.p({ class: 'world' }));
+    const txt = syncStringify(traverse(tag));
+    assert.equal(txt, '<div>hello<p class="world"></p></div>')
+  },
+
+  function TEST_OMISSION () {
+    const tag = _.div('hello', null, [false, [undefined]], 0);
+    const txt = syncStringify(traverse(tag));
+    assert.equal(txt, '<div>hello0</div>')
+  },
+
   function TEST_NESTED_EXAMPLE () {
     
     const content = _.html(

--- a/test/sync.mjs
+++ b/test/sync.mjs
@@ -17,7 +17,7 @@ export default [
   function TEST_BASIC () {
     const tag = _.div('hello', _.p({ class: 'world' }));
     const txt = syncStringify(traverse(tag));
-    assert.equal(txt, '<div>hello<p class="world"></p></div>')
+    assert.equal(txt, '<div>hello<p class="world"></p></div>');
   },
 
   function TEST_OMISSION () {


### PR DESCRIPTION
Before I was creating an array wrapper for each return from tag(). This avoids that by manipulating the arguments object with a special `-1` property.

Also, this delays attribute stringification until the traversal is happening. That way it won't happen up front synchronously